### PR TITLE
fixed typo: `true` before dynamic `showEaten` bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class App extends Component {
   toggleListMode = () => this.setState({ showEaten: !this.state.showEaten });
 
   updateFruitList = () => {
-    fetch(`/api/fruit?eaten=true${this.state.showEaten}`)
+    fetch(`/api/fruit?eaten=${this.state.showEaten}`)
       .then(response => response.json())
       .then(fruits => this.setState({ fruits }));
   }


### PR DESCRIPTION
Changed this:

```js
fetch(`/api/fruit?eaten=true${this.state.showEaten}`)
```

...to this:

```js
fetch(`/api/fruit?eaten=${this.state.showEaten}`)
```

...to reflect the abstraction afforded by the `showEaten` state boolean.